### PR TITLE
Make rustify less chatty at the info! level

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -20,7 +20,7 @@ pub trait Client {
     /// [Endpoints][crate::endpoint::Endpoint] for execution.
     #[instrument(skip(self, req), err)]
     fn execute(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, ClientError> {
-        info!(
+        debug!(
             "Client sending {} request to {} with {} bytes of data",
             req.method().to_string(),
             req.uri(),
@@ -28,7 +28,7 @@ pub trait Client {
         );
         let response = self.send(req)?;
 
-        info!(
+        debug!(
             "Client received {} response with {} bytes of body data",
             response.status().as_u16(),
             response.body().len()

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,7 +26,7 @@ pub trait Client: Sync + Send {
     /// [Endpoints][crate::endpoint::Endpoint] for execution.
     #[instrument(skip(self, req), err)]
     async fn execute(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, ClientError> {
-        info!(
+        debug!(
             "Client sending {} request to {} with {} bytes of data",
             req.method().to_string(),
             req.uri(),
@@ -34,7 +34,7 @@ pub trait Client: Sync + Send {
         );
         let response = self.send(req).await?;
 
-        info!(
+        debug!(
             "Client received {} response with {} bytes of body data",
             response.status().as_u16(),
             response.body().len()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -92,7 +92,7 @@ impl<E: Endpoint, M: MiddleWare> Endpoint for MutatedEndpoint<'_, E, M> {
         &self,
         client: &impl Client,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        info!("Executing endpoint");
+        debug!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec_mut(client, self, req, self.middleware).await?;
@@ -104,7 +104,7 @@ impl<E: Endpoint, M: MiddleWare> Endpoint for MutatedEndpoint<'_, E, M> {
         &self,
         client: &impl BlockingClient,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        info!("Executing endpoint");
+        debug!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec_block_mut(client, self, req, self.middleware)?;
@@ -226,7 +226,7 @@ pub trait Endpoint: Send + Sync + Sized {
         &self,
         client: &impl Client,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        info!("Executing endpoint");
+        debug!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec(client, req).await?;
@@ -244,7 +244,7 @@ pub trait Endpoint: Send + Sync + Sized {
         &self,
         client: &impl BlockingClient,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        info!("Executing endpoint");
+        debug!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec_block(client, req)?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -41,7 +41,7 @@ pub fn build_request(
     query: Option<String>,
     data: Option<Vec<u8>>,
 ) -> Result<Request<Vec<u8>>, ClientError> {
-    info!("Building endpoint request");
+    debug!("Building endpoint request");
     let uri = build_url(base, path, query)?;
 
     let method_err = method.clone();


### PR DESCRIPTION
This reduces all of the rustify log messages to the `debug!` level,
as this seems more apt for per-http request logging. Using the info! 
log level on each HTTP request can lead to high log load in a production 
system.