### PR TITLE
Misc tweaks

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,5 +1,0 @@
-//! Contains blocking variants of clients for executing
-//! [Endpoints][crate::endpoint::Endpoint]
-
-pub mod client;
-pub mod clients;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -22,7 +22,7 @@ pub trait Client {
     fn execute(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, ClientError> {
         debug!(
             "Client sending {} request to {} with {} bytes of data",
-            req.method().to_string(),
+            req.method(),
             req.uri(),
             req.body().len(),
         );

--- a/src/blocking/clients.rs
+++ b/src/blocking/clients.rs
@@ -1,4 +1,0 @@
-//! Contains implementations of [Client][crate::blocking::client::Client] which
-//! use varying blocking HTTP clients.
-#[cfg(feature = "reqwest")]
-pub mod reqwest;

--- a/src/blocking/clients/reqwest.rs
+++ b/src/blocking/clients/reqwest.rs
@@ -89,7 +89,7 @@ impl RustifyClient for Client {
                 response
                     .bytes()
                     .map_err(|e| ClientError::ResponseError { source: e.into() })?
-                    .to_vec(),
+                    .into(),
             )
             .map_err(|e| ClientError::ResponseError { source: e.into() })
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ pub trait Client: Sync + Send {
     async fn execute(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, ClientError> {
         debug!(
             "Client sending {} request to {} with {} bytes of data",
-            req.method().to_string(),
+            req.method(),
             req.uri(),
             req.body().len(),
         );
@@ -44,7 +44,7 @@ pub trait Client: Sync + Send {
         if !HTTP_SUCCESS_CODES.contains(&response.status().as_u16()) {
             return Err(ClientError::ServerResponseError {
                 code: response.status().as_u16(),
-                content: String::from_utf8(response.body().to_vec()).ok(),
+                content: String::from_utf8(response.into_body()).ok(),
             });
         }
 

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -1,4 +1,0 @@
-//! Contains implementations of [Client][crate::client::Client] which use
-//! varying HTTP clients.
-#[cfg(feature = "reqwest")]
-pub mod reqwest;

--- a/src/clients/reqwest.rs
+++ b/src/clients/reqwest.rs
@@ -94,7 +94,7 @@ impl RustifyClient for Client {
                     .bytes()
                     .await
                     .map_err(|e| ClientError::ResponseError { source: e.into() })?
-                    .to_vec(),
+                    .into(),
             )
             .map_err(|e| ClientError::ResponseError { source: e.into() })
     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,7 +1,7 @@
 //! Contains common enums used across the crate
 
 /// Represents a HTTP request method
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum RequestMethod {
     CONNECT,
     DELETE,
@@ -34,13 +34,13 @@ impl Into<http::Method> for RequestMethod {
 }
 
 /// Represents the type of a HTTP request body
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum RequestType {
     JSON,
 }
 
 /// Represents the type of a HTTP response body
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum ResponseType {
     JSON,
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -17,9 +17,8 @@ pub fn build_body(object: &impl Serialize, ty: RequestType) -> Result<Vec<u8>, C
             let parse_data = serde_json::to_string(object)
                 .map_err(|e| ClientError::DataParseError { source: e.into() })?;
             Ok(match parse_data.as_str() {
-                "null" => "".as_bytes().to_vec(),
-                "{}" => "".as_bytes().to_vec(),
-                _ => parse_data.as_bytes().to_vec(),
+                "null" | "{}" => Vec::new(),
+                _ => parse_data.into(),
             })
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -44,7 +44,6 @@ pub fn build_request(
     debug!("Building endpoint request");
     let uri = build_url(base, path, query)?;
 
-    let method_err = method.clone();
     let uri_err = uri.to_string();
     Request::builder()
         .uri(uri)
@@ -52,7 +51,7 @@ pub fn build_request(
         .body(data.unwrap_or_default())
         .map_err(|e| ClientError::RequestBuildError {
             source: e,
-            method: method_err,
+            method,
             url: uri_err,
         })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,17 +222,34 @@
 extern crate tracing;
 
 #[cfg(feature = "blocking")]
-pub mod blocking;
+pub mod blocking {
+    //! Contains blocking variants of clients for executing
+    //! [Endpoints][crate::endpoint::Endpoint]
+
+    pub mod client;
+    pub mod clients {
+        //! Contains implementations of [Client][crate::blocking::client::Client] which
+        //! use varying blocking HTTP clients.
+        #[cfg(feature = "reqwest")]
+        pub mod reqwest;
+    }
+}
 pub mod client;
-pub mod clients;
+pub mod clients {
+    //! Contains implementations of [Client][crate::client::Client] which use
+    //! varying HTTP clients.
+    #[cfg(feature = "reqwest")]
+    pub mod reqwest;
+}
 pub mod endpoint;
 pub mod enums;
 pub mod errors;
 pub mod http;
 
 #[doc(hidden)]
-#[path = "private/mod.rs"]
-pub mod __private;
+pub mod __private {
+    pub use serde;
+}
 
 pub use crate::{
     clients::reqwest::Client,

--- a/src/private/mod.rs
+++ b/src/private/mod.rs
@@ -1,1 +1,0 @@
-pub use serde;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -96,7 +96,7 @@ impl MiddleWare for Middle {
                 content: String::from_utf8(resp_body.to_vec()).ok(),
             })?;
         let data = wrapper.result.to_string();
-        *resp.body_mut() = data.as_bytes().to_vec();
+        *resp.body_mut() = data.into();
         Ok(())
     }
 }


### PR DESCRIPTION
* Modules don't need to exist as (tiny) files.
* Enums without a non-exhaustive attribute may as well be changed to be copyable.
* `to_vec` copies, but `into` can reuse existing allocation. 
* 
* It'd be nice to change `&self` to `self` on `execute` to avoid copying in other cases.