### PR TITLE
fix: serde attibute won't pass down

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "rustify"
-version = "0.5.3"
-authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
+name = "rustify-serde-fix"
+version = "0.1.0"
+authors = ["George Miao <gm@miao.dev>", "Joshua Gilman <joshuagilman@gmail.com>"]
 description = "A Rust library for interacting with HTTP API endpoints."
 license = "MIT"
 readme = "README.md"

--- a/rustify_derive/src/lib.rs
+++ b/rustify_derive/src/lib.rs
@@ -337,4 +337,4 @@ fn endpoint_derive(s: synstructure::Structure) -> proc_macro2::TokenStream {
     }
 }
 
-synstructure::decl_derive!([Endpoint, attributes(endpoint)] => endpoint_derive);
+synstructure::decl_derive!([Endpoint, attributes(endpoint, serde)] => endpoint_derive);

--- a/src/clients/reqwest.rs
+++ b/src/clients/reqwest.rs
@@ -33,6 +33,7 @@ use std::convert::TryFrom;
 /// ```
 ///
 /// [1]: https://docs.rs/reqwest/latest/reqwest/struct.Client.html
+#[derive(Debug, Clone)]
 pub struct Client {
     pub http: reqwest::Client,
     pub base: String,

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -81,6 +81,7 @@ impl<E: Endpoint, M: MiddleWare> Endpoint for MutatedEndpoint<'_, E, M> {
             self.method(),
             self.query()?,
             self.body()?,
+            Self::REQUEST_BODY_TYPE,
         )?;
 
         self.middleware.request(self, &mut req)?;
@@ -158,7 +159,7 @@ impl<E: Endpoint, M: MiddleWare> Endpoint for MutatedEndpoint<'_, E, M> {
 ///
 /// // Configure a client with a base URL of http://myapi.com
 /// let client = Client::default("http://myapi.com");
-///     
+///
 /// // Construct a new instance of our Endpoint
 /// let endpoint = MyEndpoint {};
 ///
@@ -217,6 +218,7 @@ pub trait Endpoint: Send + Sync + Sized {
             self.method(),
             self.query()?,
             self.body()?,
+            Self::REQUEST_BODY_TYPE,
         )
     }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,7 @@
 //! Contains common enums used across the crate
 
+use http::HeaderValue;
+
 /// Represents a HTTP request method
 #[derive(Clone, Debug)]
 pub enum RequestMethod {
@@ -37,6 +39,14 @@ impl Into<http::Method> for RequestMethod {
 #[derive(Clone, Debug)]
 pub enum RequestType {
     JSON,
+}
+
+impl From<RequestType> for HeaderValue {
+    fn from(ty: RequestType) -> Self {
+        match ty {
+            RequestType::JSON => HeaderValue::from_static("application/json"),
+        }
+    }
 }
 
 /// Represents the type of a HTTP response body

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,44 +6,44 @@ use crate::enums::RequestMethod;
 /// The general error type returned by this crate
 #[derive(Error, Debug)]
 pub enum ClientError {
-    #[error("Error parsing endpoint into data")]
+    #[error("Error parsing endpoint into data: {source}")]
     DataParseError { source: anyhow::Error },
-    #[error("Error building endpoint request")]
+    #[error("Error building endpoint request: {source}")]
     EndpointBuildError { source: anyhow::Error },
-    #[error("An error occurred in processing the request")]
+    #[error("An error occurred in processing the request: {source}")]
     GenericError { source: anyhow::Error },
-    #[error("Error sending HTTP request")]
+    #[error("Error sending HTTP request: {source}")]
     RequestError {
         source: anyhow::Error,
         url: String,
         method: String,
     },
-    #[error("Error building HTTP request")]
+    #[error("Error building HTTP request: {source}")]
     RequestBuildError {
         source: http::Error,
         method: RequestMethod,
         url: String,
     },
-    #[error("Error building request for Reqwest crate")]
+    #[error("Error building request for Reqwest crate: {source}")]
     ReqwestBuildError { source: reqwest::Error },
-    #[error("Error retrieving HTTP response")]
+    #[error("Error retrieving HTTP response: {source}")]
     ResponseError { source: anyhow::Error },
-    #[error("Error parsing server response as UTF-8")]
+    #[error("Error parsing server response as UTF-8: {source}")]
     ResponseConversionError {
         source: anyhow::Error,
         content: Vec<u8>,
     },
-    #[error("Error parsing HTTP response")]
+    #[error("Error parsing HTTP response: {source}")]
     ResponseParseError {
         source: anyhow::Error,
         content: Option<String>,
     },
-    #[error("Server returned error")]
+    #[error("Server returned error (HTTP {code})")]
     ServerResponseError { code: u16, content: Option<String> },
-    #[error("Error building URL")]
+    #[error("Error building URL: {source}")]
     UrlBuildError { source: http::uri::InvalidUri },
-    #[error("Error serializing URL query parameters")]
+    #[error("Error serializing URL query parameters: {source}")]
     UrlQueryParseError { source: anyhow::Error },
-    #[error("Error parsing URL")]
+    #[error("Error parsing URL: {source}")]
     UrlParseError { source: url::ParseError },
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,7 @@ use crate::{
     enums::{RequestMethod, RequestType},
     errors::ClientError,
 };
-use http::{Request, Uri};
+use http::{Request, Uri, header::CONTENT_TYPE};
 use serde::Serialize;
 use url::Url;
 
@@ -40,6 +40,7 @@ pub fn build_request(
     method: RequestMethod,
     query: Option<String>,
     data: Option<Vec<u8>>,
+    ty: RequestType,
 ) -> Result<Request<Vec<u8>>, ClientError> {
     debug!("Building endpoint request");
     let uri = build_url(base, path, query)?;
@@ -49,6 +50,7 @@ pub fn build_request(
     Request::builder()
         .uri(uri)
         .method(method)
+        .header(CONTENT_TYPE, ty)
         .body(data.unwrap_or_default())
         .map_err(|e| ClientError::RequestBuildError {
             source: e,


### PR DESCRIPTION
To properly handle `serde` attibute, it needs to be registered first. This PR also add appropriate `content-type` header. Missing header is causing some server to return 400 error.