### PR TITLE
bump reqwest to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ members = [
 anyhow = "1.0.56"
 async-trait = "0.1.52"
 bytes = "1.1.0"
-http = "0.2.6"
-reqwest = { version = "0.11.10", default-features = false, optional = true }
+http = "1"
+reqwest = { version = "0.12.2", default-features = false, optional = true }
 rustify_derive = { version = "0.5.2", path = "rustify_derive" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ url = "2.2.2"
 derive_builder = "0.10.2"
 env_logger = "0.9.0"
 httpmock = "0.6.6"
+rustversion = "1"
 test-log = { version = "0.2.8", features = ["trace"] }
 tokio = "1.17.0"
 tokio-test = "0.4.2"

--- a/rustify_derive/src/error.rs
+++ b/rustify_derive/src/error.rs
@@ -1,4 +1,5 @@
 use proc_macro2::Span;
+use quote::quote_spanned;
 
 /// The general error object returned by functions in this crate.
 ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,6 +24,9 @@ pub trait Client: Sync + Send {
 
     /// This method provides a common interface to
     /// [Endpoints][crate::endpoint::Endpoint] for execution.
+    // TODO: remove the allow when the upstream clippy issue is fixed:
+    // <https://github.com/rust-lang/rust-clippy/issues/12281>
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip(self, req), err)]
     async fn execute(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, ClientError> {
         debug!(

--- a/src/clients/reqwest.rs
+++ b/src/clients/reqwest.rs
@@ -65,6 +65,9 @@ impl RustifyClient for Client {
         self.base.as_str()
     }
 
+    // TODO: remove the allow when the upstream clippy issue is fixed:
+    // <https://github.com/rust-lang/rust-clippy/issues/12281>
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip(self, req), err)]
     async fn send(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, ClientError> {
         let request = reqwest::Request::try_from(req)

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -87,6 +87,9 @@ impl<E: Endpoint, M: MiddleWare> Endpoint for MutatedEndpoint<'_, E, M> {
         Ok(req)
     }
 
+    // TODO: remove the allow when the upstream clippy issue is fixed:
+    // <https://github.com/rust-lang/rust-clippy/issues/12281>
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip(self, client), err)]
     async fn exec(
         &self,
@@ -221,6 +224,9 @@ pub trait Endpoint: Send + Sync + Sized {
     }
 
     /// Executes the Endpoint using the given [Client].
+    // TODO: remove the allow when the upstream clippy issue is fixed:
+    // <https://github.com/rust-lang/rust-clippy/issues/12281>
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip(self, client), err)]
     async fn exec(
         &self,

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -1,3 +1,4 @@
+#[rustversion::attr(not(nightly), ignore)]
 #[test]
 fn test_macro() {
     let t = trybuild::TestCases::new();

--- a/tests/macro/empty_attr.stderr
+++ b/tests/macro/empty_attr.stderr
@@ -1,0 +1,19 @@
+error: Cannot parse attribute as list
+ --> tests/macro/empty_attr.rs:6:3
+  |
+6 | #[endpoint]
+  |   ^^^^^^^^
+
+error: Attribute cannot be empty
+  --> tests/macro/empty_attr.rs:10:3
+   |
+10 | #[endpoint()]
+   |   ^^^^^^^^
+
+warning: unused import: `rustify::endpoint::Endpoint`
+ --> tests/macro/empty_attr.rs:1:5
+  |
+1 | use rustify::endpoint::Endpoint;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/macro/empty_attr.stderr
+++ b/tests/macro/empty_attr.stderr
@@ -8,7 +8,7 @@ error: Attribute cannot be empty
   --> tests/macro/empty_attr.rs:10:3
    |
 10 | #[endpoint()]
-   |   ^^^^^^^^
+   |   ^^^^^^^^^^
 
 warning: unused import: `rustify::endpoint::Endpoint`
  --> tests/macro/empty_attr.rs:1:5

--- a/tests/macro/invalid_data.stderr
+++ b/tests/macro/invalid_data.stderr
@@ -1,8 +1,9 @@
 error: May only mark one field as raw
   --> tests/macro/invalid_data.rs:19:5
    |
-19 |     #[endpoint(raw)]
-   |     ^
+19 | /     #[endpoint(raw)]
+20 | |     pub data_two: Vec<u8>,
+   | |_________________________^
 
 warning: unused import: `rustify::endpoint::Endpoint`
  --> tests/macro/invalid_data.rs:1:5
@@ -30,9 +31,6 @@ help: the type constructed contains `std::string::String` due to the type of the
   |                 ^^^^^^^^ this argument influences the type of `Some`
 note: tuple variant defined here
  --> $RUST/core/src/option.rs
-  |
-  |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
-  |     ^^^^
   = note: this error originates in the derive macro `Endpoint` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: call `Into::into` on this expression to convert `std::string::String` into `Vec<u8>`
   |

--- a/tests/macro/invalid_data.stderr
+++ b/tests/macro/invalid_data.stderr
@@ -1,0 +1,40 @@
+error: May only mark one field as raw
+  --> tests/macro/invalid_data.rs:19:5
+   |
+19 |     #[endpoint(raw)]
+   |     ^
+
+warning: unused import: `rustify::endpoint::Endpoint`
+ --> tests/macro/invalid_data.rs:1:5
+  |
+1 | use rustify::endpoint::Endpoint;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0308]: mismatched types
+ --> tests/macro/invalid_data.rs:5:17
+  |
+5 | #[derive(Debug, Endpoint, Serialize)]
+  |                 ^^^^^^^^
+  |                 |
+  |                 expected `Vec<u8>`, found `String`
+  |                 arguments to this enum variant are incorrect
+  |
+  = note: expected struct `Vec<u8>`
+             found struct `std::string::String`
+help: the type constructed contains `std::string::String` due to the type of the argument passed
+ --> tests/macro/invalid_data.rs:5:17
+  |
+5 | #[derive(Debug, Endpoint, Serialize)]
+  |                 ^^^^^^^^ this argument influences the type of `Some`
+note: tuple variant defined here
+ --> $RUST/core/src/option.rs
+  |
+  |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+  |     ^^^^
+  = note: this error originates in the derive macro `Endpoint` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: call `Into::into` on this expression to convert `std::string::String` into `Vec<u8>`
+  |
+5 | #[derive(Debug, Endpoint.into(), Serialize)]
+  |                         +++++++

--- a/tests/macro/invalid_method.stderr
+++ b/tests/macro/invalid_method.stderr
@@ -1,0 +1,13 @@
+warning: unused import: `rustify::endpoint::Endpoint`
+ --> tests/macro/invalid_method.rs:1:5
+  |
+1 | use rustify::endpoint::Endpoint;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0599]: no variant or associated item named `TEST` found for enum `RequestMethod` in the current scope
+ --> tests/macro/invalid_method.rs:6:41
+  |
+6 | #[endpoint(path = "test/path", method = "TEST")]
+  |                                         ^^^^^^ variant or associated item not found in `RequestMethod`

--- a/tests/macro/invalid_result.stderr
+++ b/tests/macro/invalid_result.stderr
@@ -1,0 +1,13 @@
+error: Unknown parameter
+ --> tests/macro/invalid_result.rs:6:32
+  |
+6 | #[endpoint(path = "test/path", result = "DoesNotExist")]
+  |                                ^^^^^^
+
+warning: unused import: `rustify::endpoint::Endpoint`
+ --> tests/macro/invalid_result.rs:1:5
+  |
+1 | use rustify::endpoint::Endpoint;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/macro/invalid_type.stderr
+++ b/tests/macro/invalid_type.stderr
@@ -1,0 +1,19 @@
+warning: unused import: `rustify::endpoint::Endpoint`
+ --> tests/macro/invalid_type.rs:1:5
+  |
+1 | use rustify::endpoint::Endpoint;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0599]: no variant or associated item named `BAD` found for enum `RequestType` in the current scope
+ --> tests/macro/invalid_type.rs:6:47
+  |
+6 | #[endpoint(path = "test/path", request_type = "BAD", response_type = "BAD")]
+  |                                               ^^^^^ variant or associated item not found in `RequestType`
+
+error[E0599]: no variant or associated item named `BAD` found for enum `ResponseType` in the current scope
+ --> tests/macro/invalid_type.rs:6:70
+  |
+6 | #[endpoint(path = "test/path", request_type = "BAD", response_type = "BAD")]
+  |                                                                      ^^^^^ variant or associated item not found in `ResponseType`

--- a/tests/macro/no_attr.stderr
+++ b/tests/macro/no_attr.stderr
@@ -1,0 +1,15 @@
+error: Deriving `Endpoint` requires attaching an `endpoint` attribute
+ --> tests/macro/no_attr.rs:5:17
+  |
+5 | #[derive(Debug, Endpoint, Serialize)]
+  |                 ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Endpoint` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused import: `rustify::endpoint::Endpoint`
+ --> tests/macro/no_attr.rs:1:5
+  |
+1 | use rustify::endpoint::Endpoint;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/macro/no_path.stderr
+++ b/tests/macro/no_path.stderr
@@ -1,0 +1,15 @@
+error: Missing required parameter: path
+ --> tests/macro/no_path.rs:5:17
+  |
+5 | #[derive(Debug, Endpoint, Serialize)]
+  |                 ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Endpoint` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused import: `rustify::endpoint::Endpoint`
+ --> tests/macro/no_path.rs:1:5
+  |
+1 | use rustify::endpoint::Endpoint;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default


### PR DESCRIPTION
Bump reqwest to 0.12 unlocking:
- use of rustls 0.22 
- use hyper 1.0 
- use of http 1.0

@jmgilman I know you have been very busy lately, but could you please consider merging this.
This PR is very small (2 lines) and contains only trivial changes. 

