### PR TITLE
Bump version to 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2024-04-02
+
+### Changed
+
+- Bump request to 0.12
+
 ## [0.5.3] - 2022-03-15
 
 ### Fixed
@@ -166,7 +172,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[unreleased]: https://github.com/jmgilman/rustify/compare/v0.5.3..HEAD
+[unreleased]: https://github.com/jmgilman/rustify/compare/v0.5.4..HEAD
+[0.5.4]: https://github.com/jmgilman/rustify/releases/tag/v0.5.4
 [0.5.3]: https://github.com/jmgilman/rustify/releases/tag/v0.4.4
 [0.5.2]: https://github.com/jmgilman/rustify/releases/tag/v0.5.2
 [0.5.1]: https://github.com/jmgilman/rustify/releases/tag/v0.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustify"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
 description = "A Rust library for interacting with HTTP API endpoints."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add rustify as a dependency to your cargo.toml:
 
 ```toml
 [dependencies]
-rustify = "0.5.3"
+rustify = "0.5.4"
 rustify_derive = "0.5.2"
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ```ignore
 //! [dependencies]
-//! rustify = "0.5.3"
+//! rustify = "0.5.4"
 //! rustify_derive = "0.5.2"
 //! ```
 //!


### PR DESCRIPTION
Hello again @jmgilman , I prepared a release PR that include the bump of `reqwest` version https://github.com/jmgilman/rustify/pull/17

I know you are still very busy, I would very much welcome if you could find time to review this.