### PR TITLE
Fixes build with `default-features = false`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,8 +24,11 @@ pub enum ClientError {
         method: RequestMethod,
         url: String,
     },
+
+    #[cfg(feature = "reqwest")]
     #[error("Error building request for Reqwest crate")]
     ReqwestBuildError { source: reqwest::Error },
+
     #[error("Error retrieving HTTP response")]
     ResponseError { source: anyhow::Error },
     #[error("Error parsing server response as UTF-8")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,6 @@ pub mod http;
 #[path = "private/mod.rs"]
 pub mod __private;
 
-pub use crate::{
-    clients::reqwest::Client,
-    endpoint::{Endpoint, MiddleWare, Wrapper},
-};
+#[cfg(feature = "reqwest")]
+pub use crate::clients::reqwest::Client;
+pub use crate::endpoint::{Endpoint, MiddleWare, Wrapper};


### PR DESCRIPTION
If you try to build this crate with `default-features = false`, you get this:

```
error[E0432]: unresolved import `crate::clients::reqwest`
   --> src/lib.rs:238:14
    |
238 |     clients::reqwest::Client,
    |              ^^^^^^^ could not find `reqwest` in `clients`
    |
note: found an item that was configured out
   --> src/clients.rs:4:9
    |
4   | pub mod reqwest;
    |         ^^^^^^^
note: the item is gated behind the `reqwest` feature
   --> src/clients.rs:3:7
    |
3   | #[cfg(feature = "reqwest")]
    |       ^^^^^^^^^^^^^^^^^^^

error[E0433]: failed to resolve: use of undeclared crate or module `reqwest`
  --> src/errors.rs:28:33
   |
28 |     ReqwestBuildError { source: reqwest::Error },
   |                                 ^^^^^^^ use of undeclared crate or module `reqwest`

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `rustify` (lib) due to 2 previous errors
```