### PR TITLE
Improve debug log fields when executing requests

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -18,20 +18,21 @@ pub trait Client {
 
     /// This method provides a common interface to
     /// [Endpoints][crate::endpoint::Endpoint] for execution.
-    #[instrument(skip(self, req), err)]
+    #[instrument(skip(self, req), fields(uri=%req.uri(), method=%req.method()), err)]
     fn execute(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, ClientError> {
         debug!(
-            "Client sending {} request to {} with {} bytes of data",
-            req.method().to_string(),
-            req.uri(),
-            req.body().len(),
+            name: "sending_request",
+            body_len=req.body().len(),
+            "Sending Request",
         );
         let response = self.send(req)?;
-
+        let status = response.status();
         debug!(
-            "Client received {} response with {} bytes of body data",
-            response.status().as_u16(),
-            response.body().len()
+            name: "response_received",
+            status=status.as_u16(),
+            response_len=response.body().len(),
+            is_error=status.is_client_error() || status.is_server_error(),
+            "Response Received",
         );
 
         // Check response

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -95,7 +95,7 @@ impl<E: Endpoint, M: MiddleWare> Endpoint for MutatedEndpoint<'_, E, M> {
         &self,
         client: &impl Client,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        debug!("Executing endpoint");
+        trace!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec_mut(client, self, req, self.middleware).await?;
@@ -107,7 +107,7 @@ impl<E: Endpoint, M: MiddleWare> Endpoint for MutatedEndpoint<'_, E, M> {
         &self,
         client: &impl BlockingClient,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        debug!("Executing endpoint");
+        trace!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec_block_mut(client, self, req, self.middleware)?;
@@ -232,7 +232,7 @@ pub trait Endpoint: Send + Sync + Sized {
         &self,
         client: &impl Client,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        debug!("Executing endpoint");
+        trace!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec(client, req).await?;
@@ -250,7 +250,7 @@ pub trait Endpoint: Send + Sync + Sized {
         &self,
         client: &impl BlockingClient,
     ) -> Result<EndpointResult<Self::Response>, ClientError> {
-        debug!("Executing endpoint");
+        trace!("Executing endpoint");
 
         let req = self.request(client.base())?;
         let resp = exec_block(client, req)?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -41,7 +41,7 @@ pub fn build_request(
     query: Option<String>,
     data: Option<Vec<u8>>,
 ) -> Result<Request<Vec<u8>>, ClientError> {
-    debug!("Building endpoint request");
+    trace!("Building endpoint request");
     let uri = build_url(base, path, query)?;
 
     let method_err = method.clone();


### PR DESCRIPTION
First: this is a fantastic library, thank you! <3

One issue we've run into is that the logs are quite verbose. This MR makes the (very useful) sending/receiving `debug!` calls add fields with the method, status, uri, status and content length.

This enables one to set a logging directive like `rustify::client[{success=false}]=debug` to log all unsuccessful requests to the console, whilst skipping successful ones.

I also moved some verbose `executing endpoint` `debug!` calls to be `trace!` instead.