### PR TITLE
fix(rustify_derive): remove derive block expr to fix LSP type inference

### DIFF
--- a/rustify_derive/src/parse.rs
+++ b/rustify_derive/src/parse.rs
@@ -219,7 +219,7 @@ pub(crate) fn fields_to_struct(fields: &[Field], attrs: &[Meta]) -> proc_macro2:
         .collect::<Vec<proc_macro2::TokenStream>>();
 
     quote! {
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         #(#attrs)*
         struct __Temp<'a> {
             #(#def)*


### PR DESCRIPTION
This updates `rustify_derive` to remove the block expression that the `impl Endpoint` was wrapped in.

This resolves an issue where `rust-analyzer` is unable to infer the type of `Endpoint::Response` in some cases. The issue is described at:
- https://github.com/jmgilman/rustify/issues/28

## 🔧 Changes

- Removes the block expression `const #const_ident: () = {...};` wrapping `impl Endpoint` in the derive macro
- Removes the convenience `use` imports that were contained in this block expression
- Updates usage of those imported types to use fully qualified type paths e.g. `RequestMethod` -> `rustify::enums::RequestMethod`

### ◀️ Backwards-Compatibility

I believe this fix is backwards-compatible, but I invite others to check me on that.

Since `vaultrs` uses `rustify`, I checked `vaultrs` on `master` ([aaa7ff6](https://github.com/jmgilman/vaultrs/commit/aaa7ff66d01f49e4b4ab67bf9a355b1b1a66106e)) with `rustify_derive` dependency pointed at this branch.

`cargo build` succeeds and `cargo clippy` reports two unused `serde::Serialize` imports:

```
warning: unused import: `serde::Serialize`
 --> src/api/identity/entity_alias/requests.rs:5:5
  |
5 | use serde::Serialize;
  |     ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `serde::Serialize`
 --> src/api/identity/entity/requests.rs:2:5
  |
2 | use serde::Serialize;
  |     ^^^^^^^^^^^^^^^^
```

This is likely due to switching to `serde::Serialize` in the macro. I think not requiring this `use` is an improvement, but if we prefer I can adjust the PR.

## ✅ Testing

- Verified that these changes allow `rust-analyzer` to infer response types in my editor.
  - I tested this with the same example case described in #28, as well as in my project using this library.
- Ran checks/lints/tests/examples locally:
  - `cargo test`
  - `cargo check`
  - `cargo clippy`
  - `cargo run --package rustify --example reqres1`
  - `cargo run --package rustify --example reqres2`