### PR TITLE
fix: empty path segments produced by `build_url()`

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -71,3 +71,62 @@ pub fn build_url(base: &str, path: &str, query: Option<String>) -> Result<Uri, C
         .parse::<Uri>()
         .map_err(|e| ClientError::UrlBuildError { source: e })
 }
+
+#[cfg(test)]
+mod test {
+    use super::build_url;
+
+    #[test]
+    fn build_url_path_with_trailing_slash() {
+        let url = build_url("https://192.0.2.2", "foobar/", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/foobar/");
+    }
+
+    #[test]
+    fn build_url_base_without_path_and_path_without_slash() {
+        let url = build_url("https://192.0.2.2", "foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/foobar");
+    }
+
+    #[test]
+    fn build_url_base_without_path_and_path_with_slash() {
+        let url = build_url("https://192.0.2.2", "/foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/foobar");
+    }
+
+    #[test]
+    fn build_url_base_with_trailing_slash_and_path_without_slash() {
+        let url = build_url("https://192.0.2.2/", "foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/foobar");
+    }
+
+    #[test]
+    fn build_url_base_with_trailing_slash_and_path_with_slash() {
+        let url = build_url("https://192.0.2.2/", "/foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/foobar");
+    }
+
+    #[test]
+    fn build_url_base_with_path_and_path_without_slash() {
+        let url = build_url("https://192.0.2.2/base/path", "foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/base/path/foobar");
+    }
+
+    #[test]
+    fn build_url_base_with_path_and_path_with_slash() {
+        let url = build_url("https://192.0.2.2/base/path", "/foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/base/path/foobar");
+    }
+
+    #[test]
+    fn build_url_base_with_path_and_trailing_slash_and_path_without_slash() {
+        let url = build_url("https://192.0.2.2/base/path/", "foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/base/path/foobar");
+    }
+
+    #[test]
+    fn build_url_base_with_path_and_trailing_slash_and_path_with_slash() {
+        let url = build_url("https://192.0.2.2/base/path/", "/foobar", None).unwrap();
+        assert_eq!(url.to_string(), "https://192.0.2.2/base/path/foobar");
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -62,7 +62,16 @@ pub fn build_request(
 #[instrument(skip(query), err)]
 pub fn build_url(base: &str, path: &str, query: Option<String>) -> Result<Uri, ClientError> {
     let mut url = Url::parse(base).map_err(|e| ClientError::UrlParseError { source: e })?;
-    url.path_segments_mut().unwrap().extend(path.split('/'));
+
+    // remove leading `/` from path to avoid double `//` when base has a path
+    let path = path.strip_prefix('/').unwrap_or(path);
+
+    url.path_segments_mut()
+        .unwrap()
+        // avoids double `//` when base path has trailing slash
+        .pop_if_empty()
+        .extend(path.split('/'));
+
     if let Some(q) = query {
         url.set_query(Some(q.as_str()));
     }


### PR DESCRIPTION
When testing my middleware in another project I noticed that `rustify` will sometimes produce extraneous `//` in the `Uri` produced by `http::build_url()`.

This is due to some unhandled cases where base path, trailing slashes, and path with leading slashes may result in adding empty path segments to the joined path.

## Testing & Failure Cases

This PR adds 9 different test cases. Prior to the fix, 3 were failing.

You can checkout f7ab901c79bcf66fab20973b925b5f0c30f97404 and `cargo test` to reproduce.

### Example

This is an example similar to how I stumbled on this:

```rust
    use rustify::Endpoint;
    use rustify_derive::Endpoint;

    #[derive(Endpoint)]
    #[endpoint(path = "/endpoint")]
    struct ExampleEndpoint {
        #[endpoint(query)]
        hello: String,
    }

    #[test]
    fn rustify_build_url_extra_slash_example() {
        let endpoint = ExampleEndpoint {
            hello: "world".into(),
        };
        let expected = "https://192.0.2.2/api/endpoint?hello=world";

        let request_uri = endpoint.request("https://192.0.2.2/api").unwrap();

        assert_eq!(request_uri.uri(), expected);
    }
```
```
assertion `left == right` failed
  left: https://192.0.2.2/api//endpoint?hello=world
 right: "https://192.0.2.2/api/endpoint?hello=world"
```

This issue doesn't really impact actual HTTP requesting / library usage, but may surprise developers trying to write tests. :) 

## Fix

`build_url()` is adjust to better avoid empty path segments by:
- popping off empty segment on the base URL path (for cases where it had a trailing slash)
- stripping the leading `/` from the endpoint/relative path (to avoid adding an empty path segment)