### PR TITLE
Adds a simple bearer token authorization wrapper for a client

### DIFF
--- a/src/clients/reqwest.rs
+++ b/src/clients/reqwest.rs
@@ -1,7 +1,7 @@
 //! Contains an implementation of [Client][crate::client::Client] being backed
 //! by the [reqwest](https://docs.rs/reqwest/) crate.
 
-use crate::{client::Client as RustifyClient, errors::ClientError};
+use crate::{client::{Client as RustifyClient, BearerTokenAuthClient}, errors::ClientError};
 use async_trait::async_trait;
 use http::{Request, Response};
 use std::convert::TryFrom;
@@ -100,5 +100,12 @@ impl RustifyClient for Client {
                     .to_vec(),
             )
             .map_err(|e| ClientError::ResponseError { source: e.into() })
+    }
+}
+
+impl BearerTokenAuthClient<Client> {
+    /// Construct from a default client using a given base URL and a bearer token.
+    pub fn default(base: &str, token: &str) -> Self {
+        BearerTokenAuthClient::new(Client::default(base), token)
     }
 }


### PR DESCRIPTION
This provides support for performing OAuth 2.0 Bearer Token Authorization ([RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)) by setting an `Authorization` header to a fixed token value within the client.

While it is true that it is possible to do that using a `MiddleWare`, the code becomes much more cumbersome in cases where middleware is not used otherwise. Having a per Client "middleware" rather than per request makes more sense in case of authorization (see for example #22).