### PR TITLE
Depend on `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1.0.56"
 async-trait = "0.1.52"
 bytes = "1.1.0"
 http = "1"
-reqwest = { version = "0.12.2", default-features = false, optional = true }
+reqwest = { version = "0.12.2", default-features = false, optional = false }
 rustify_derive = { version = "0.5.4", path = "rustify_derive" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["reqwest/default-tls"]
+default = ["reqwest"]
 blocking = ["reqwest/blocking"]
 rustls-tls = ["reqwest/rustls-tls"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 default = ["reqwest"]
 blocking = ["reqwest/blocking"]
 rustls-tls = ["reqwest/rustls-tls"]
-request = []
+reqwest = []
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 default = ["reqwest"]
 blocking = ["reqwest/blocking"]
 rustls-tls = ["reqwest/rustls-tls"]
+request = []
 
 [workspace]
 members = [


### PR DESCRIPTION
A reqwest import exists in errors.rs.

Therefore reqwest should be a required dependency. This also removes the default feature selection `default-tls` which should be a decision left for application authors.